### PR TITLE
Update menu-directive.ts

### DIFF
--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -54,6 +54,9 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   @ContentChildren(MdMenuItem) items: QueryList<MdMenuItem>;
   @Input() overlapTrigger = true;
 
+  /** Wether the preventClose for menu instance is asked or not.*/
+  @Input("preventClose") preventClose:boolean = false;
+
   constructor(@Attribute('xPosition') posX: MenuPositionX,
               @Attribute('yPosition') posY: MenuPositionY,
               @Attribute('x-position') deprecatedPosX: MenuPositionX,
@@ -113,6 +116,17 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
    */
   _emitCloseEvent(): void {
     this.close.emit();
+  }
+  
+  /**
+   * This emits a close event to which the trigger is subscribed, only when a user
+   * click inside menu panel and prevent close attribute/input is false. When emitted,
+   * the trigger will close the menu.
+   */
+  _emitClickCloseEvent(): void {
+    if(!this.preventClose){
+      this.close.emit();
+    }
   }
 
   private _setPositionX(pos: MenuPositionX): void {


### PR DESCRIPTION

![menu-caveate](https://cloud.githubusercontent.com/assets/5689298/25610441/d11071cc-2f40-11e7-9697-55e26cb9a7ab.gif)
As It's a feature the core team decided to add, and I was in need of this feature for functionality like drop-down menu having some setting controls where user may want to change multiple settings in one go. As currently after every click inside or outside of drop-down menu, it disappears. But adding some additional check based on the value of preventClose @Input() supplied parent node can add this desired functionality. Actually I am creating a emoji picker, and have multiple categories of emoji, so user is required to change the category by clicking on tabs(Yeah I am using MD-tabs), menu disappears so this feature will help in accomplishing my specific requirement, and other people's similar requirements.